### PR TITLE
Allow the application to be "app of apps"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,15 +24,9 @@ resource "kubernetes_manifest" "argo_application" {
       source = {
         repoURL        = var.repo_url
         targetRevision = var.target_revision
-        chart          = var.chart
         path           = var.path
         directory = {
           recurse = var.directory_recurse
-        }
-        helm = {
-          releaseName = var.release_name == null ? var.name : var.release_name
-          parameters  = local.helm_parameters
-          values      = yamlencode(merge({ labels = local.labels }, var.helm_values))
         }
       }
       destination = {

--- a/main.tf
+++ b/main.tf
@@ -26,6 +26,9 @@ resource "kubernetes_manifest" "argo_application" {
         targetRevision = var.target_revision
         chart          = var.chart
         path           = var.path
+        directory = {
+          recurse = var.directory_recurse
+        }
         helm = {
           releaseName = var.release_name == null ? var.name : var.release_name
           parameters  = local.helm_parameters

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,11 @@ variable "path" {
   description = ""
   default     = ""
 }
+variable "directory_recurse" {
+  type        = bool
+  description = "Recursively search for manifests in the specified path"
+  default     = false
+}
 variable "release_name" {
   type        = string
   description = "Release name override (defaults to application name)"

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,11 @@ variable "target_revision" {
   description = "Revision of the Helm application manifests to use"
   default     = ""
 }
+
+variable "use_chart" {
+  type    = bool
+  default = true
+}
 variable "chart" {
   type        = string
   description = "The name of the Helm chart"

--- a/variables.tf
+++ b/variables.tf
@@ -79,7 +79,7 @@ variable "automated_prune" {
 variable "automated_self_heal" {
   type        = bool
   description = "Specifies if partial app sync should be executed when resources are changed only in target Kubernetes cluster and no git change detected"
-  default     = false
+  default     = null
 }
 variable "sync_options" {
   type        = list(string)


### PR DESCRIPTION
This PR contributes a feature to allow the Helm chart to have the flag "directory_recurse", so it can be used to bootstrap a Terraform cluster; and let the rest be managed by ArgoCD itself.

It also removes the hard-coded automated self_heal=false. 

Because we should not always assume it is deployed with Helm, and I don't think this section is necessary, I removed the helm section as well. 

Happy to make further adjustments to make it more largely applicable.